### PR TITLE
Adjust code blocks font to JetBrains Mono

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -1,17 +1,11 @@
 @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@100..900&display=swap");
-
-* {
-  font-family: "Noto Sans Thai", sans-serif;
-  font-optical-sizing: auto;
-  font-style: normal;
-  font-variation-settings: "wdth" 100;
-}
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap');
 
 :root {
+  --vp-font-family-base: "Noto Sans Thai", sans-serif;
+  --vp-font-family-mono: "JetBrains Mono", monospace;
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: -webkit-linear-gradient(
-    120deg,
-    #bd34fe,
-    #41d1ff
-  );
+  --vp-home-hero-name-background: -webkit-linear-gradient(120deg,
+      #bd34fe,
+      #41d1ff);
 }


### PR DESCRIPTION
I felt like "monospace" type fonts should be use when you got some code snippets going on, since it looked better than sans-serif that way. Also, there's [a simpler way](https://vitepress.dev/guide/extending-default-theme#using-different-fonts) to use different fonts.

## Before
![Screenshot from 2024-10-07 11-27-10](https://github.com/user-attachments/assets/468df8e2-6433-4d77-aac3-210b06138d2e)

---

## After
![Screenshot from 2024-10-07 11-26-25](https://github.com/user-attachments/assets/97434339-3c0c-4acd-9be1-9037e1152c6b)

